### PR TITLE
レビュー用PR_2023_03_24に関しての修正

### DIFF
--- a/PluginManager.php
+++ b/PluginManager.php
@@ -113,8 +113,8 @@ class PluginManager extends AbstractPluginManager
     protected function createPages(EntityManagerInterface $em)
     {
         foreach ($this->pages as $p) {
-            $Page = $em->getRepository(Page::class)->findOneBy(['url' => $p[0]]);
-            if (!$Page) {
+            $hasPage = $em->getRepository(Page::class)->count(['url' => $p[0]]) > 0;
+            if (!$hasPage) {
                 /** @var \Eccube\Entity\Page $Page */
                 $Page = $em->getRepository(Page::class)->newPage();
                 $Page->setEditType(Page::EDIT_TYPE_DEFAULT);

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -11,7 +11,7 @@ eccube:
       limit: 5
       # インターバルを設定します。
       interval: '30 minutes'
-    app_challenge_request:
+    plg_customer_2fa_app_challenge:
       # 実行するルーティングを指定します。
       route: plg_customer_2fa_app_challenge
       # 実行するmethodを指定します。デフォルトはPOSTです。

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -1,6 +1,6 @@
 eccube:
   rate_limiter:
-    app_create_request:
+    plg_customer_2fa_app_create:
       # 実行するルーティングを指定します。
       route: plg_customer_2fa_app_create
       # 実行するmethodを指定します。デフォルトはPOSTです。


### PR DESCRIPTION
https://github.com/EC-CUBE/TwoFactorAuthCustomer42/pull/3#discussion_r1147157803
について、他の-`>findOneBy([〇〇]) === null`箇所の代わりに`count`関数を利用するように更新しました。

https://github.com/EC-CUBE/TwoFactorAuthCustomer42/pull/3#issuecomment-1482332934
について、スロットリングパラメータはルーティング名と合わせました。